### PR TITLE
change query signature

### DIFF
--- a/pkg/datasource/sample-datasource.go
+++ b/pkg/datasource/sample-datasource.go
@@ -47,19 +47,22 @@ type queryModel struct {
 	Format string `json:"format"`
 }
 
-func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) (response backend.DataResponse) {
+func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) backend.DataResponse {
 	// Unmarshal the json into our queryModel
 	var qm queryModel
+
+	response := backend.DataResponse{}
+
 	response.Error = json.Unmarshal(query.JSON, &qm)
 	if response.Error != nil {
-		return
+		return response
 	}
 
 	// Return an error is `Format` iis empty. Returning an error on the `DataResponse`
 	// will allow others queries to be executed.
 	if qm.Format == "" {
 		response.Error = errors.New("format cannot be empty")
-		return
+		return response
 	}
 
 	// create data frame response
@@ -78,7 +81,7 @@ func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) 
 	// add the frames to the response
 	response.Frames = append(response.Frames, frame)
 
-	return
+	return response
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin.

--- a/pkg/datasource/sample-datasource.go
+++ b/pkg/datasource/sample-datasource.go
@@ -33,10 +33,7 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 
 	// loop over queries and execute them individually.
 	for _, q := range req.Queries {
-		res, err := td.query(ctx, q)
-		if err != nil {
-			return nil, err
-		}
+		res := td.query(ctx, q)
 
 		// save the response in a hashmap
 		// based on with RefID as identifier
@@ -50,21 +47,19 @@ type queryModel struct {
 	Format string `json:"format"`
 }
 
-func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) (backend.DataResponse, error) {
+func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) (response backend.DataResponse) {
 	// Unmarshal the json into our queryModel
 	var qm queryModel
-	response := backend.DataResponse{}
-	err := json.Unmarshal(query.JSON, &qm)
-	if err != nil {
-		return response, err
+	response.Error = json.Unmarshal(query.JSON, &qm)
+	if response.Error != nil {
+		return
 	}
 
 	// Return an error is `Format` iis empty. Returning an error on the `DataResponse`
-	// will allow others queries to be executed. If we return an error as the second
-	// param we expect to halt all queries.
+	// will allow others queries to be executed.
 	if qm.Format == "" {
 		response.Error = errors.New("format cannot be empty")
-		return response, nil
+		return
 	}
 
 	// create data frame response
@@ -83,7 +78,7 @@ func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) 
 	// add the frames to the response
 	response.Frames = append(response.Frames, frame)
 
-	return response, nil
+	return
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin.


### PR DESCRIPTION
I don't think returning an error from query is a good pattern (although, one might return an error from functions within it, and then assign to response.Error).

Could restore comment about what happens when returning an error to the handle in calling function. Don't care about the named return if you don't want to use it here, but I think cleaner when there is no initialization to do and a single return param. 